### PR TITLE
Add cross-platform socket support for ROS TCP endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,15 @@ target_include_directories(${PROJECT_NAME}
     $<INSTALL_INTERFACE:include>
   )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
-target_compile_definitions(${PROJECT_NAME} PUBLIC NOMINMAX) # WIN32_LEAN_AND_MEAN
+if(WIN32)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC NOMINMAX _WIN32_WINNT=0x0600)
+else()
+  target_compile_definitions(${PROJECT_NAME} PUBLIC NOMINMAX)
+endif()
+
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} ws2_32)
+endif()
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})

--- a/cpp/include/clientThread.hpp
+++ b/cpp/include/clientThread.hpp
@@ -29,7 +29,7 @@ public:
 	std::pair<std::string, std::string> read_message();
 
 	void send_ros_service_request(int srv_id, const std::string& destination, const RosData&data);
-	void service_call_thread(int srv_id, const std::string& destination, const RosData&data, std::shared_ptr<RosService>& rosService);
+	void service_call_thread(int srv_id, const std::string& destination, const RosData&data, std::shared_ptr<RosService> rosService);
 	std::shared_ptr<RosNode> get_node_for_topic(const std::string& topic);
 
 private:

--- a/cpp/include/clientThread.hpp
+++ b/cpp/include/clientThread.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include <WinSock2.h>
 #include <memory>
 #include <string>
 #include <map>
 #include <regex>
 #include <functional>
+#include "socket_utils.hpp"
 #include "unityTcpSender.hpp"
 #include "rosSubscriber.hpp"
 #include "rosPublisher.hpp"

--- a/cpp/include/socket_utils.hpp
+++ b/cpp/include/socket_utils.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifdef _WIN32
+#  include <WinSock2.h>
+#  include <WS2tcpip.h>
+using socket_len_t = int;
+inline int last_socket_error() {
+    return WSAGetLastError();
+}
+#else
+#  include <sys/types.h>
+#  include <sys/socket.h>
+#  include <netinet/in.h>
+#  include <arpa/inet.h>
+#  include <unistd.h>
+#  include <cerrno>
+
+using SOCKET = int;
+constexpr SOCKET INVALID_SOCKET = -1;
+constexpr int SOCKET_ERROR = -1;
+using socket_len_t = socklen_t;
+
+inline int closesocket(SOCKET socket) {
+    return ::close(socket);
+}
+inline int last_socket_error() {
+    return errno;
+}
+#ifndef WSAECONNABORTED
+#define WSAECONNABORTED ECONNABORTED
+#endif
+#ifndef WSAECONNRESET
+#define WSAECONNRESET ECONNRESET
+#endif
+#endif

--- a/cpp/include/tcpServerNode.hpp
+++ b/cpp/include/tcpServerNode.hpp
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <string>
 #include <cstdarg>
-#include <WinSock2.h>
+#include "socket_utils.hpp"
 
 class TcpServerNode : public rclcpp::Node {
 public:

--- a/cpp/include/unityTcpSender.hpp
+++ b/cpp/include/unityTcpSender.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <chrono>
 #include "statusEvent.hpp"
-#include <WinSock2.h>
+#include "socket_utils.hpp"
 #include "rosCommunication.hpp"
 #include "threadPauser.hpp"
 #include "sysCommands.hpp"

--- a/cpp/include/unityTcpSender.hpp
+++ b/cpp/include/unityTcpSender.hpp
@@ -34,10 +34,10 @@ public:
 	RosData send_unity_service_request(const std::string& topic, const RosData& request);
     void send_unity_service_response(int srv_id, const RosData& data);
     void send_topic_list(const SysCommand::TopicsResponse &topics_response);
-	void start_sender(SOCKET socket, std::shared_ptr<StatusEvent>& event);
+	void start_sender(SOCKET socket, std::shared_ptr<StatusEvent> event);
 
 private:
-	void sender_loop(SOCKET socket, std::shared_ptr<StatusEvent>& event);
+	void sender_loop(SOCKET socket, std::shared_ptr<StatusEvent> event);
 	std::string serialize_message(const std::string& destination, const RosData& message);
 	std::string serialize_command(const std::string& command, const std::string& params);
 	void add_to_queue(const std::string &data, Reliability reliablity);

--- a/cpp/src/clientThread.cpp
+++ b/cpp/src/clientThread.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <sstream>
 #include <regex>
+#include <array>
 #include "clientThread.hpp"
 #include "tcpServerNode.hpp"
 
@@ -42,8 +43,11 @@ void ClientThread::recvall(char *buffer, int size) {
     while (pos < size) {
         int read = recv(socket, buffer + pos, size - pos, 0);
         if (SOCKET_ERROR == read) {
-            tcp_server->log_error("recvall - Unable to read from socket: %d", WSAGetLastError());
+            tcp_server->log_error("recvall - Unable to read from socket: %d", last_socket_error());
             throw std::runtime_error{"socket error"};
+        }
+        if (read == 0) {
+            throw std::runtime_error{"socket closed"};
         }
         pos += read;
     }
@@ -137,8 +141,12 @@ void ClientThread::run() {
     pending_srv_id = NO_PENDING_SERVICE_ID;
     pending_srv_is_request = false;
 
-    const auto& remote_addr = remote.sin_addr.S_un.S_un_b;
-    tcp_server->log_info("Connection from %hhu.%hhu.%hhu.%hhu:%hu", remote_addr.s_b1, remote_addr.s_b2, remote_addr.s_b3, remote_addr.s_b4, ntohs(remote.sin_port));
+    std::array<char, INET_ADDRSTRLEN> remote_addr{};
+    if (nullptr == inet_ntop(AF_INET, &remote.sin_addr, remote_addr.data(), remote_addr.size())) {
+        tcp_server->log_warning("Failed to convert remote address to string: %d", last_socket_error());
+        remote_addr[0] = '\0';
+    }
+    tcp_server->log_info("Connection from %s:%hu", remote_addr.data(), ntohs(remote.sin_port));
     unity_tcp_sender.start_sender(socket, halt_event);
 
     try {
@@ -191,7 +199,12 @@ void ClientThread::run() {
     halt_event->set();
     closesocket(socket);
     unregister_all();
-    tcp_server->log_info("Disconnected from %hhu.%hhu.%hhu.%hhu:%hu", remote_addr.s_b1, remote_addr.s_b2, remote_addr.s_b3, remote_addr.s_b4, ntohs(remote.sin_port));
+    if (remote_addr[0] == '\0') {
+        if (nullptr == inet_ntop(AF_INET, &remote.sin_addr, remote_addr.data(), remote_addr.size())) {
+            tcp_server->log_warning("Failed to convert remote address to string: %d", last_socket_error());
+        }
+    }
+    tcp_server->log_info("Disconnected from %s:%hu", remote_addr.data(), ntohs(remote.sin_port));
 
     run_is_finished = true;
 }

--- a/cpp/src/clientThread.cpp
+++ b/cpp/src/clientThread.cpp
@@ -94,7 +94,7 @@ void ClientThread::send_ros_service_request(int srv_id, const std::string& desti
     }
 }
 
-void ClientThread::service_call_thread(int srv_id, const std::string& destination, const RosData &data, std::shared_ptr<RosService>& rosService) {
+void ClientThread::service_call_thread(int srv_id, const std::string& destination, const RosData &data, std::shared_ptr<RosService> rosService) {
     RosData response;
     if (!rosService->send(data, response)) {
         std::string error_msg = "No response data from service '" + destination + "'!";
@@ -193,7 +193,7 @@ void ClientThread::run() {
                 }
             }
         }
-    } catch (std::exception ex) {
+    } catch (const std::exception& ex) {
         tcp_server->log_error("exception occured in ClientThread: %s", ex.what());
     }
     halt_event->set();
@@ -210,7 +210,7 @@ void ClientThread::run() {
 }
 
 void ClientThread::register_subscriber(const std::string& topic, const std::string& message_type) {
-    auto& old_node = subscribers_table.find(topic);
+    auto old_node = subscribers_table.find(topic);
     if (old_node != subscribers_table.end()) {
         tcp_server->unregister_node(std::reinterpret_pointer_cast<RosNode>(old_node->second));
     }
@@ -221,7 +221,8 @@ void ClientThread::register_subscriber(const std::string& topic, const std::stri
 }
 
 void ClientThread::register_publisher(const std::string& topic, const std::string& message_type, int queue_size, bool latch) {
-    auto& old_node = publishers_table.find(topic);
+    static_cast<void>(latch);
+    auto old_node = publishers_table.find(topic);
     if (old_node != publishers_table.end()) {
         tcp_server->unregister_node(std::reinterpret_pointer_cast<RosNode>(old_node->second));
     }
@@ -232,7 +233,7 @@ void ClientThread::register_publisher(const std::string& topic, const std::strin
 }
 
 void ClientThread::register_ros_service(const std::string& topic, const std::string& request_message_type) {
-    auto& old_node = ros_services_table.find(topic);
+    auto old_node = ros_services_table.find(topic);
     if (old_node != ros_services_table.end()) {
         tcp_server->unregister_node(std::reinterpret_pointer_cast<RosNode>(old_node->second));
     }
@@ -243,7 +244,7 @@ void ClientThread::register_ros_service(const std::string& topic, const std::str
 }
 
 void ClientThread::register_unity_service(const std::string& topic, const std::string& request_message_type) {
-    auto& old_node = unity_services_table.find(topic);
+    auto old_node = unity_services_table.find(topic);
     if (old_node != unity_services_table.end()) {
         tcp_server->unregister_node(std::reinterpret_pointer_cast<RosNode>(old_node->second));
     }

--- a/cpp/src/rosService.cpp
+++ b/cpp/src/rosService.cpp
@@ -50,8 +50,9 @@ bool RosService::send(const RosData &request, RosData &response) {
         }
         */
 
-    if (!RosSerialization::serialize_message(future_result.get(), response, service_response_members, service_ts->response_typesupport))
+    if (!RosSerialization::serialize_message(future_result.get(), response, service_response_members, service_ts->response_typesupport)) {
         return false;
+    }
 
 	return true;
 }

--- a/cpp/src/tcpServerNode.cpp
+++ b/cpp/src/tcpServerNode.cpp
@@ -1,6 +1,4 @@
 #include "tcpServerNode.hpp"
-#include <WS2tcpip.h>
-#pragma comment(lib, "Ws2_32.lib")
 #include "clientThread.hpp"
 
 using namespace std::chrono_literals;
@@ -30,6 +28,7 @@ bool TcpServerNode::init(int connections, const std::string &tcp_ip, int tcp_por
     
     this->connections = connections;
 
+#ifdef _WIN32
     // Initialize Winsock
     WSADATA wsaData;
     int iResult = WSAStartup(MAKEWORD(2, 2), &wsaData);
@@ -37,6 +36,7 @@ bool TcpServerNode::init(int connections, const std::string &tcp_ip, int tcp_por
         RCUTILS_LOG_ERROR("WSAStartup failed: %d", iResult);
         return false;
     }
+#endif
 
 	return true;
 }
@@ -54,7 +54,9 @@ void TcpServerNode::shutdown() {
         server_thread.join();
     }
     executor.reset();
+#ifdef _WIN32
     WSACleanup();
+#endif
 }
 
 void TcpServerNode::start() {
@@ -132,12 +134,12 @@ void TcpServerNode::listen_loop() {
 
     tcp_server = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (tcp_server == INVALID_SOCKET) {
-        RCUTILS_LOG_ERROR("Unable to create socket : %d", WSAGetLastError());
+        RCUTILS_LOG_ERROR("Unable to create socket : %d", last_socket_error());
         return;
     }
-    DWORD reuse_addr = TRUE;
-    if (SOCKET_ERROR == setsockopt(tcp_server, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&reuse_addr), sizeof(reuse_addr))) {
-        RCUTILS_LOG_ERROR("setsockopt failed : %d", WSAGetLastError());
+    int reuse_addr = 1;
+    if (SOCKET_ERROR == setsockopt(tcp_server, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse_addr), sizeof(reuse_addr))) {
+        RCUTILS_LOG_ERROR("setsockopt failed : %d", last_socket_error());
         closesocket(tcp_server);
         tcp_server = INVALID_SOCKET;
         return;
@@ -146,14 +148,14 @@ void TcpServerNode::listen_loop() {
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
     if (1 != inet_pton(AF_INET, tcp_ip.c_str(), &addr.sin_addr)) {
-        RCUTILS_LOG_ERROR("inet_pton failed with ip '%s' : %d", tcp_ip, WSAGetLastError());
+        RCUTILS_LOG_ERROR("inet_pton failed with ip '%s' : %d", tcp_ip.c_str(), last_socket_error());
         closesocket(tcp_server);
         tcp_server = INVALID_SOCKET;
         return;
     }
     addr.sin_port = htons(tcp_port);
     if (SOCKET_ERROR == bind(tcp_server, reinterpret_cast<sockaddr*>(&addr), sizeof(addr))) {
-        RCUTILS_LOG_ERROR("bind failed : %d", WSAGetLastError());
+        RCUTILS_LOG_ERROR("bind failed : %d", last_socket_error());
         closesocket(tcp_server);
         tcp_server = INVALID_SOCKET;
         return;
@@ -161,17 +163,17 @@ void TcpServerNode::listen_loop() {
 
     while (!stop_server_thread) {
         if (SOCKET_ERROR == listen(tcp_server, connections)) {
-            RCUTILS_LOG_ERROR("listen failed : %d", WSAGetLastError());
+            RCUTILS_LOG_ERROR("listen failed : %d", last_socket_error());
             closesocket(tcp_server);
             tcp_server = INVALID_SOCKET;
             return;
         }
 
         sockaddr_in client_addr{};
-        int client_addr_len = sizeof(client_addr);
+        socket_len_t client_addr_len = static_cast<socket_len_t>(sizeof(client_addr));
         SOCKET client_socket = accept(tcp_server, reinterpret_cast<sockaddr*>(&client_addr), &client_addr_len);
         if (client_socket == INVALID_SOCKET) {
-            RCUTILS_LOG_ERROR("unable to accept incoming connection request : %d", WSAGetLastError());
+            RCUTILS_LOG_ERROR("unable to accept incoming connection request : %d", last_socket_error());
         } else {
             std::shared_ptr<ClientThread> clientThread = std::make_shared<ClientThread>(this, client_socket, client_addr);
             {

--- a/cpp/src/tcpServerNode.cpp
+++ b/cpp/src/tcpServerNode.cpp
@@ -11,21 +11,21 @@ TcpServerNode::TcpServerNode(const std::string &name) : rclcpp::Node(name) {}
 bool TcpServerNode::init(int connections, const std::string &tcp_ip, int tcp_port) {
 	std::string param_ip = declare_parameter<std::string>(rosIPParameter, "0.0.0.0");
 	int param_port = static_cast<int>(declare_parameter<int>(rosPortParameter, 10000));
-    
+
     if (!tcp_ip.empty()) {
 		RCUTILS_LOG_INFO("Using ROS_IP override from constructor: %s", tcp_ip.c_str());
         this->tcp_ip = tcp_ip;
     } else {
         this->tcp_ip = param_ip;
     }
-    
+
     if (tcp_port != 0) {
 		RCUTILS_LOG_INFO("Using ROS_TCP_PORT override from constructor: %d", tcp_port);
         this->tcp_port = tcp_port;
     } else {
         this->tcp_port = param_port;
     }
-    
+
     this->connections = connections;
 
 #ifdef _WIN32
@@ -95,7 +95,7 @@ void TcpServerNode::log_debug(const char* msg, ...) {
     va_start(args, msg);
     ok = get_log_string(msg, args);
     va_end(args);
-    if (ok) RCUTILS_LOG_DEBUG(log_buffer);
+    if (ok) RCUTILS_LOG_DEBUG("%s", log_buffer);
 }
 
 void TcpServerNode::log_info(const char *msg, ...) {
@@ -105,7 +105,7 @@ void TcpServerNode::log_info(const char *msg, ...) {
     va_start(args, msg);
     ok = get_log_string(msg, args);
     va_end(args);
-    if (ok) RCUTILS_LOG_INFO(log_buffer);
+    if (ok) RCUTILS_LOG_INFO("%s", log_buffer);
 }
 
 void TcpServerNode::log_warning(const char* msg, ...) {
@@ -115,7 +115,7 @@ void TcpServerNode::log_warning(const char* msg, ...) {
     va_start(args, msg);
     ok = get_log_string(msg, args);
     va_end(args);
-    if (ok) RCUTILS_LOG_WARN(log_buffer);
+    if (ok) RCUTILS_LOG_WARN("%s", log_buffer);
 }
 
 void TcpServerNode::log_error(const char *msg, ...) {
@@ -125,7 +125,7 @@ void TcpServerNode::log_error(const char *msg, ...) {
     va_start(args, msg);
     ok = get_log_string(msg, args);
     va_end(args);
-    if (ok) RCUTILS_LOG_ERROR(log_buffer);
+    if (ok) RCUTILS_LOG_ERROR("%s", log_buffer);
 }
 
 
@@ -179,7 +179,7 @@ void TcpServerNode::listen_loop() {
             {
                 const std::lock_guard<std::mutex> clients_lock(client_threads_mutex);
                 // remove finished threads
-                for (auto& iter = client_threads.begin(); iter != client_threads.end(); iter++) {
+                for (auto iter = client_threads.begin(); iter != client_threads.end(); iter++) {
                     if ((*iter)->is_finished()) {
                         (*iter)->wait();
                         iter = client_threads.erase(iter);

--- a/cpp/src/unityService.cpp
+++ b/cpp/src/unityService.cpp
@@ -6,6 +6,7 @@
 
 UnityService::UnityService(UnityTcpSender* unity_tcp_sender, const std::string& service_topic, const std::string &service_type, int queue_size)
 	: RosReceiver(unity_tcp_sender, service_topic + "_service", service_topic) {
+    static_cast<void>(queue_size);
 
     // get typesupport informations for request and response types
     ts_lib = rclcpp::get_typesupport_library(service_type, "rosidl_typesupport_cpp");

--- a/cpp/src/unityTcpSender.cpp
+++ b/cpp/src/unityTcpSender.cpp
@@ -71,7 +71,7 @@ void UnityTcpSender::sender_loop(SOCKET socket, std::shared_ptr<StatusEvent>& ha
 		while (!halt_event->is_set()) {
 			if (try_remove_from_queue(data)) {
 				if (SOCKET_ERROR == send(socket, data.c_str(), static_cast<int>(data.size()), 0)) {
-					int err = WSAGetLastError();
+					int err = last_socket_error();
 					tcp_server->log_error("socket send error %d", err);
 					if (WSAECONNABORTED == err || WSAECONNRESET == err)
 						break;
@@ -106,7 +106,7 @@ std::string UnityTcpSender::serialize_command(const std::string& command, const 
 	//little endian.  uint32 taille de la command, puis les octets de la commande
 	std::ostringstream oss;
 	append_string(oss, command);
-	//todo: encodage utf - 8 des params, à voir si nécessaire
+	//todo: encodage utf - 8 des params,  voir si ncessaire
 	append_string(oss, params);
 
 	return oss.str();

--- a/cpp/src/unityTcpSender.cpp
+++ b/cpp/src/unityTcpSender.cpp
@@ -57,14 +57,14 @@ void UnityTcpSender::send_topic_list(const SysCommand::TopicsResponse& topics_re
 	add_to_queue(serialize_command(SysCommand::k_SysCommand_TopicList, SysCommand::serialize_TopicsResponse(topics_response)), Reliability::Reliable);
 }
 
-void UnityTcpSender::start_sender(SOCKET socket, std::shared_ptr<StatusEvent>& halt_event) {
+void UnityTcpSender::start_sender(SOCKET socket, std::shared_ptr<StatusEvent> halt_event) {
 	// send a handshake message to confirm the connection and version number
 	add_to_queue(serialize_command(SysCommand::k_SysCommand_Handshake, SysCommand::serialize_Handshake()), Reliability::Reliable);
 
 	std::thread(&UnityTcpSender::sender_loop, this, socket, halt_event).detach();
 }
 
-void UnityTcpSender::sender_loop(SOCKET socket, std::shared_ptr<StatusEvent>& halt_event) {
+void UnityTcpSender::sender_loop(SOCKET socket, std::shared_ptr<StatusEvent> halt_event) {
 	std::string data;
 
 	try {
@@ -78,9 +78,9 @@ void UnityTcpSender::sender_loop(SOCKET socket, std::shared_ptr<StatusEvent>& ha
 				}
 			}
 		}
-	} catch (std::exception ex) {
-		tcp_server->log_error("exception occured in UnityTcpSender: %s", ex.what());
-	}
+    } catch (const std::exception& ex) {
+        tcp_server->log_error("exception occured in UnityTcpSender: %s", ex.what());
+    }
 	// make sure this one is called
 	halt_event->set();
 }
@@ -156,7 +156,7 @@ void UnityTcpSender::append_size(std::ostringstream& oss, uint32_t size) {
 
 void UnityTcpSender::append_string(std::ostringstream& oss, const std::string& data) {
 	uint32_t size = static_cast<uint32_t>(data.size());
-	append_size(oss, static_cast<uint32_t>(data.size()));
+	append_size(oss, size);
 	oss << data;
 }
 void UnityTcpSender::append_ros_data(std::ostringstream& oss, const RosData& ros_data) {
@@ -164,4 +164,3 @@ void UnityTcpSender::append_ros_data(std::ostringstream& oss, const RosData& ros
 	append_size(oss, size);
 	oss.write(reinterpret_cast<const char*>(ros_data.data()), size);
 }
-


### PR DESCRIPTION
## Summary
- introduce a platform abstraction header so the TCP endpoint can build on Windows and Linux
- update the TCP server, client thread, and Unity sender implementations to use the shared socket helpers and POSIX-compatible logging
- adjust CMake configuration to add required Windows definitions and link libraries conditionally

## Testing
- colcon build --packages-select ros_tcp_endpoint *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5389ea74c832c8d3d2ce08a728de7